### PR TITLE
AArch64 support

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,12 +1,12 @@
 pkgbase = step-ca-bin
 	pkgdesc = An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere.
-	pkgver = 0.14.4
+	pkgver = 0.14.5
 	pkgrel = 1
 	url = https://smallstep.com/certificates
 	arch = x86_64
 	license = Apache
-	source = https://github.com/smallstep/certificates/releases/download/v0.14.4/step-certificates_linux_0.14.4_amd64.tar.gz
-	sha256sums = 60ccc26f0baee66898ad3f05f0c15069c17861cded2b3c58bee40e12e7f51343
+	source = https://github.com/smallstep/certificates/releases/download/v0.14.5/step-certificates_linux_0.14.5_amd64.tar.gz
+	sha256sums = 4be357776c78643847ce3a43eb5761e8217dc48a0b461aff5c6aa4a2e87f23c3
 
 pkgname = step-ca-bin
 

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,12 +1,15 @@
 pkgbase = step-ca-bin
 	pkgdesc = An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere.
 	pkgver = 0.14.6
-	pkgrel = 1
+	pkgrel = 2
 	url = https://smallstep.com/certificates
 	arch = x86_64
+	arch = aarch64
 	license = Apache
-	source = https://github.com/smallstep/certificates/releases/download/v0.14.6/step-certificates_linux_0.14.6_amd64.tar.gz
-	sha256sums = 3b026b5a1603eb6fae3b6f24dc78ef2e73e416f11fb5bcf0edaad5663ea1107c
+	source_x86_64 = https://github.com/smallstep/certificates/releases/download/v0.14.6/step-certificates_linux_0.14.6_amd64.tar.gz
+	sha256sums_x86_64 = 3b026b5a1603eb6fae3b6f24dc78ef2e73e416f11fb5bcf0edaad5663ea1107c
+	source_aarch64 = https://github.com/smallstep/certificates/releases/download/v0.14.6/step-certificates_linux_0.14.6_arm64.tar.gz
+	sha256sums_aarch64 = 851307a59a73843a907150ae8ec89b664af481c95816088ff4c6e3ad0e30d9ec
 
 pkgname = step-ca-bin
 

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,12 +1,12 @@
 pkgbase = step-ca-bin
 	pkgdesc = An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere.
-	pkgver = 0.14.5
+	pkgver = 0.14.6
 	pkgrel = 1
 	url = https://smallstep.com/certificates
 	arch = x86_64
 	license = Apache
-	source = https://github.com/smallstep/certificates/releases/download/v0.14.5/step-certificates_linux_0.14.5_amd64.tar.gz
-	sha256sums = 4be357776c78643847ce3a43eb5761e8217dc48a0b461aff5c6aa4a2e87f23c3
+	source = https://github.com/smallstep/certificates/releases/download/v0.14.6/step-certificates_linux_0.14.6_amd64.tar.gz
+	sha256sums = 3b026b5a1603eb6fae3b6f24dc78ef2e73e416f11fb5bcf0edaad5663ea1107c
 
 pkgname = step-ca-bin
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Nazar Mishturak <nazarmx@gmail.com>
 _binname=step-ca
 pkgname=$_binname-bin
-pkgver=0.14.4
+pkgver=0.14.5
 pkgrel=1
 pkgdesc="An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere."
 arch=('x86_64')
@@ -11,7 +11,7 @@ url="https://smallstep.com/certificates"
 license=('Apache')
 
 source=("https://github.com/smallstep/certificates/releases/download/v${pkgver}/step-certificates_linux_${pkgver}_amd64.tar.gz")
-sha256sums=('60ccc26f0baee66898ad3f05f0c15069c17861cded2b3c58bee40e12e7f51343')
+sha256sums=('4be357776c78643847ce3a43eb5761e8217dc48a0b461aff5c6aa4a2e87f23c3')
 
 package() {
 	install -Dm755 "step-certificates_$pkgver/bin/$_binname" "$pkgdir/usr/bin/$_binname"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Nazar Mishturak <nazarmx@gmail.com>
 _binname=step-ca
 pkgname=$_binname-bin
-pkgver=0.14.5
+pkgver=0.14.6
 pkgrel=1
 pkgdesc="An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere."
 arch=('x86_64')
@@ -11,7 +11,7 @@ url="https://smallstep.com/certificates"
 license=('Apache')
 
 source=("https://github.com/smallstep/certificates/releases/download/v${pkgver}/step-certificates_linux_${pkgver}_amd64.tar.gz")
-sha256sums=('4be357776c78643847ce3a43eb5761e8217dc48a0b461aff5c6aa4a2e87f23c3')
+sha256sums=('3b026b5a1603eb6fae3b6f24dc78ef2e73e416f11fb5bcf0edaad5663ea1107c')
 
 package() {
 	install -Dm755 "step-certificates_$pkgver/bin/$_binname" "$pkgdir/usr/bin/$_binname"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,14 +4,16 @@
 _binname=step-ca
 pkgname=$_binname-bin
 pkgver=0.14.6
-pkgrel=1
+pkgrel=2
 pkgdesc="An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere."
-arch=('x86_64')
+arch=('x86_64' 'aarch64')
 url="https://smallstep.com/certificates"
 license=('Apache')
 
-source=("https://github.com/smallstep/certificates/releases/download/v${pkgver}/step-certificates_linux_${pkgver}_amd64.tar.gz")
-sha256sums=('3b026b5a1603eb6fae3b6f24dc78ef2e73e416f11fb5bcf0edaad5663ea1107c')
+source_x86_64=("https://github.com/smallstep/certificates/releases/download/v${pkgver}/step-certificates_linux_${pkgver}_amd64.tar.gz")
+sha256sums_x86_64=('3b026b5a1603eb6fae3b6f24dc78ef2e73e416f11fb5bcf0edaad5663ea1107c')
+source_aarch64=("https://github.com/smallstep/certificates/releases/download/v${pkgver}/step-certificates_linux_${pkgver}_arm64.tar.gz")
+sha256sums_aarch64=("851307a59a73843a907150ae8ec89b664af481c95816088ff4c6e3ad0e30d9ec")
 
 package() {
 	install -Dm755 "step-certificates_$pkgver/bin/$_binname" "$pkgdir/usr/bin/$_binname"


### PR DESCRIPTION
Add support for installing the aarch64 build to PKGBUILD for Raspberry Pi users.

Context: https://github.com/smallstep/cli/issues/342

In theory the same approach could be used for arm7 builds (corresponds to armv7h in Arch), but I don't have a installation to test arm7 on so I only changed it for aarch64. 

I forked off the AUR mirror originally, which seems to be a couple of commits ahead of this github mirror, so probably you want to push the latest commits from the AUR repo to the github repo before merging this PR so they don't appear to be part of this PR.